### PR TITLE
Implement account linking

### DIFF
--- a/src/main/kotlin/cancelcloud/PurpurInsightPlugin.kt
+++ b/src/main/kotlin/cancelcloud/PurpurInsightPlugin.kt
@@ -3,31 +3,10 @@ package cancelcloud
 import org.bukkit.plugin.java.JavaPlugin
 import cancelcloud.config.BotConfig
 import cancelcloud.listener.PlayerListener
-import cancelcloud.command.StatsCommand
-import cancelcloud.command.PingCommand
-import cancelcloud.command.AutoUpdatesCommand
 import cancelcloud.command.DiscordChannelCommand
-import cancelcloud.command.LinkDiscordCommand
-import cancelcloud.service.StatsService
 import cancelcloud.service.LinkService
-import cancelcloud.util.EmbedBuilderUtil
-
-// JDA & JDA-KTX
-import net.dv8tion.jda.api.requests.GatewayIntent
-import net.dv8tion.jda.api.events.session.ReadyEvent
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.interactions.commands.OptionType
-import net.dv8tion.jda.api.JDA
-
-import dev.minn.jda.ktx.jdabuilder.light
-import dev.minn.jda.ktx.events.listener
-import dev.minn.jda.ktx.events.onCommand
-import dev.minn.jda.ktx.jdabuilder.intents
-import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import cancelcloud.service.BotService
 import java.io.File
-import org.bukkit.scheduler.BukkitTask
-import java.util.UUID
 
 class PurpurInsightPlugin : JavaPlugin() {
     companion object {
@@ -35,261 +14,32 @@ class PurpurInsightPlugin : JavaPlugin() {
     }
 
     private lateinit var botConfig: BotConfig
-    lateinit var jda: JDA
-    var autoUpdateMinutes: Long = 30
-    private var updateTask: BukkitTask? = null
-    private var monitorTask: BukkitTask? = null
-    private var playerAlert = false
-    private var memoryAlert = false
-    private var cpuAlert = false
-    private var tpsAlert = false
-    private var diskAlert = false
 
     override fun onEnable() {
         instance = this
 
-        // Stelle sicher, dass die Default-Konfiguration existiert
-        if (!dataFolder.exists()) {
-            dataFolder.mkdirs()
-        }
+        if (!dataFolder.exists()) dataFolder.mkdirs()
         val cfgFile = File(dataFolder, "config.yml")
         if (!cfgFile.exists()) {
             saveDefaultConfig()
             logger.info("§econfig.yml wurde erstellt. Bitte fülle sie aus und starte den Server neu.")
-            // Plugin deaktivieren, bis der Benutzer die Konfiguration angepasst hat
             server.pluginManager.disablePlugin(this)
             return
         }
 
-
         saveDefaultConfig()
         botConfig = BotConfig.load(config)
-        autoUpdateMinutes = config.getLong("auto-update-minutes", 30)
 
-        // Spieler-Zeitlistener registrieren
         server.pluginManager.registerEvents(PlayerListener(), this)
         LinkService.load(this)
 
-        // Serverbefehl registrieren
         getCommand("purpurinsight")?.setExecutor(DiscordChannelCommand())
         getCommand("purpurinsight")?.tabCompleter = DiscordChannelCommand()
 
-        startBot()
-        startAutoUpdates()
-        startMonitoring()
+        BotService.init(this, botConfig)
     }
 
     override fun onDisable() {
-        updateTask?.cancel()
-        monitorTask?.cancel()
-        if (this::jda.isInitialized) {
-            jda.shutdownNow()
-        }
-    }
-
-    private fun startAutoUpdates() {
-        updateTask?.cancel()
-        if (autoUpdateMinutes <= 0) return
-        val ticks = autoUpdateMinutes * 60L * 20L
-        updateTask = server.scheduler.runTaskTimer(this, Runnable {
-            val stats = StatsService.collectAll()
-            val embed = EmbedBuilderUtil.buildEmbed(stats).build()
-            val channel = jda.getTextChannelById(botConfig.statsChannelId)
-            channel?.sendMessageEmbeds(embed)?.queue()
-        }, ticks, ticks)
-    }
-
-    private fun startMonitoring() {
-        monitorTask?.cancel()
-        val interval = 60L * 20L // every minute
-        monitorTask = server.scheduler.runTaskTimer(this, Runnable {
-            val stats = StatsService.collectAll()
-            val channel = jda.getTextChannelById(botConfig.adminChannelId)
-            channel ?: return@Runnable
-
-            val playerLoad = stats.onlinePlayers.toDouble() / stats.maxPlayers
-            if (playerLoad >= 0.8 && !playerAlert) {
-                channel.sendMessage("Player count high: ${stats.onlinePlayers}/${stats.maxPlayers}").queue()
-                playerAlert = true
-            } else if (playerLoad < 0.7) {
-                playerAlert = false
-            }
-
-            val memLoad = stats.ramUsed.toDouble() / stats.ramMax
-            if (memLoad >= 0.9 && !memoryAlert) {
-                channel.sendMessage("Memory usage critical: ${(memLoad*100).toInt()}%").queue()
-                memoryAlert = true
-            } else if (memLoad < 0.8) {
-                memoryAlert = false
-            }
-
-            if (stats.cpuLoad >= 90 && !cpuAlert) {
-                channel.sendMessage("CPU load critical: ${"%.1f".format(stats.cpuLoad)}%").queue()
-                cpuAlert = true
-            } else if (stats.cpuLoad < 80) {
-                cpuAlert = false
-            }
-
-            if (stats.tps1 < 15 && !tpsAlert) {
-                channel.sendMessage("TPS low: ${"%.2f".format(stats.tps1)}").queue()
-                tpsAlert = true
-            } else if (stats.tps1 >= 16) {
-                tpsAlert = false
-            }
-
-            val diskUsage = 1.0 - stats.diskFree.toDouble() / stats.diskTotal
-            if (diskUsage >= 0.9 && !diskAlert) {
-                channel.sendMessage("Disk almost full: ${(diskUsage*100).toInt()}% used").queue()
-                diskAlert = true
-            } else if (diskUsage < 0.85) {
-                diskAlert = false
-            }
-        }, interval, interval)
-    }
-
-    fun updateInterval(minutes: Long) {
-        autoUpdateMinutes = minutes
-        config.set("auto-update-minutes", minutes)
-        saveConfig()
-        startAutoUpdates()
-    }
-
-    private fun startBot() {
-
-        jda = light(botConfig.token, enableCoroutines = true) {
-            intents += listOf(
-                GatewayIntent.GUILD_MESSAGES,
-                GatewayIntent.MESSAGE_CONTENT
-            )
-        }
-
-        jda.listener<ReadyEvent> {
-            val guild = it.jda.getGuildById(botConfig.guildId)
-            guild?.upsertCommand(botConfig.commandName, "Zeigt Server-Statistiken")?.queue()
-            guild?.upsertCommand("ping", "Zeigt Bot-Latenz")?.queue()
-            guild?.upsertCommand("auto-updates", "Setzt Intervall f\u00fcr automatische Updates")
-                ?.addOption(OptionType.INTEGER, "minutes", "Intervall in Minuten (0 zum Deaktivieren)", false)
-                ?.queue()
-            guild?.upsertCommand("link", "Verkn\u00fcpft Discord mit Minecraft")
-                ?.addOption(OptionType.STRING, "player", "Minecraft Spieler", true)
-                ?.queue()
-        }
-
-        jda.onCommand(botConfig.commandName) { event: GenericCommandInteractionEvent ->
-            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
-            StatsCommand(slashEvent)
-        }
-
-        jda.onCommand("ping") { event: GenericCommandInteractionEvent ->
-            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
-            PingCommand(slashEvent)
-        }
-
-        jda.onCommand("auto-updates") { event: GenericCommandInteractionEvent ->
-            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
-            AutoUpdatesCommand(slashEvent)
-        }
-
-        jda.onCommand("link") { event: GenericCommandInteractionEvent ->
-            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
-            LinkDiscordCommand(slashEvent)
-        }
-
-        jda.listener<ButtonInteractionEvent> { e ->
-            if (e.componentId.startsWith("link:")) {
-                val uuid = UUID.fromString(e.componentId.substringAfter("link:"))
-                val req = LinkService.getRequestByDiscord(e.user.idLong)
-                if (req == uuid) {
-                    LinkService.takeRequest(uuid)
-                    LinkService.link(uuid, e.user.idLong)
-                    e.reply("Accounts linked!").setEphemeral(true).queue()
-                } else {
-                    e.reply("No request found.").setEphemeral(true).queue()
-                }
-            }
-        }
-
-        startAutoUpdates()
-        startMonitoring()
-    }
-
-
-    fun restartBot() {
-        updateTask?.cancel()
-        monitorTask?.cancel()
-        if (this::jda.isInitialized) {
-            jda.shutdownNow()
-        }
-
-        botConfig = BotConfig.load(config)
-        startBot()
-        startAutoUpdates()
-        startMonitoring()
-        
-    private fun startAutoUpdates() {
-        updateTask?.cancel()
-        if (autoUpdateMinutes <= 0) return
-        val ticks = autoUpdateMinutes * 60L * 20L
-        updateTask = server.scheduler.runTaskTimer(this, Runnable {
-            val stats = StatsService.collectAll()
-            val embed = EmbedBuilderUtil.buildEmbed(stats).build()
-            val channel = jda.getTextChannelById(botConfig.statsChannelId)
-            channel?.sendMessageEmbeds(embed)?.queue()
-        }, ticks, ticks)
-    }
-
-    private fun startMonitoring() {
-        monitorTask?.cancel()
-        val interval = 60L * 20L // every minute
-        monitorTask = server.scheduler.runTaskTimer(this, Runnable {
-            val stats = StatsService.collectAll()
-            val channel = jda.getTextChannelById(botConfig.adminChannelId)
-            channel ?: return@Runnable
-
-            val playerLoad = stats.onlinePlayers.toDouble() / stats.maxPlayers
-            if (playerLoad >= 0.8 && !playerAlert) {
-                channel.sendMessage("Player count high: ${stats.onlinePlayers}/${stats.maxPlayers}").queue()
-                playerAlert = true
-            } else if (playerLoad < 0.7) {
-                playerAlert = false
-            }
-
-            val memLoad = stats.ramUsed.toDouble() / stats.ramMax
-            if (memLoad >= 0.9 && !memoryAlert) {
-                channel.sendMessage("Memory usage critical: ${(memLoad*100).toInt()}%").queue()
-                memoryAlert = true
-            } else if (memLoad < 0.8) {
-                memoryAlert = false
-            }
-
-            if (stats.cpuLoad >= 90 && !cpuAlert) {
-                channel.sendMessage("CPU load critical: ${"%.1f".format(stats.cpuLoad)}%").queue()
-                cpuAlert = true
-            } else if (stats.cpuLoad < 80) {
-                cpuAlert = false
-            }
-
-            if (stats.tps1 < 15 && !tpsAlert) {
-                channel.sendMessage("TPS low: ${"%.2f".format(stats.tps1)}").queue()
-                tpsAlert = true
-            } else if (stats.tps1 >= 16) {
-                tpsAlert = false
-            }
-
-            val diskUsage = 1.0 - stats.diskFree.toDouble() / stats.diskTotal
-            if (diskUsage >= 0.9 && !diskAlert) {
-                channel.sendMessage("Disk almost full: ${(diskUsage*100).toInt()}% used").queue()
-                diskAlert = true
-            } else if (diskUsage < 0.85) {
-                diskAlert = false
-            }
-        }, interval, interval)
-    }
-
-    fun updateInterval(minutes: Long) {
-        autoUpdateMinutes = minutes
-        config.set("auto-update-minutes", minutes)
-        saveConfig()
-        startAutoUpdates()
+        BotService.shutdown()
     }
 }

--- a/src/main/kotlin/cancelcloud/command/AutoUpdatesCommand.kt
+++ b/src/main/kotlin/cancelcloud/command/AutoUpdatesCommand.kt
@@ -1,18 +1,17 @@
 package cancelcloud.command
 
-import cancelcloud.PurpurInsightPlugin
+import cancelcloud.service.BotService
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 
 object AutoUpdatesCommand {
     operator fun invoke(event: SlashCommandInteractionEvent) {
         val minutes = event.getOption("minutes")?.asLong
-        val plugin = PurpurInsightPlugin.instance
         if (minutes == null) {
-            event.reply("Aktuelles Intervall: ${plugin.autoUpdateMinutes} Minuten")
+            event.reply("Aktuelles Intervall: ${BotService.intervalMinutes} Minuten")
                 .setEphemeral(true).queue()
             return
         }
-        plugin.updateInterval(minutes)
+        BotService.updateInterval(minutes)
         if (minutes <= 0) {
             event.reply("Automatische Updates deaktiviert.").queue()
         } else {

--- a/src/main/kotlin/cancelcloud/command/DiscordChannelCommand.kt
+++ b/src/main/kotlin/cancelcloud/command/DiscordChannelCommand.kt
@@ -1,6 +1,11 @@
 package cancelcloud.command
 
 import cancelcloud.PurpurInsightPlugin
+import cancelcloud.service.LinkService
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.interactions.components.buttons.Button
+import org.bukkit.entity.Player
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender
@@ -14,7 +19,7 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
         }
         val plugin = PurpurInsightPlugin.instance
         if (args.isEmpty()) {
-            sender.sendMessage("\u00a7cUsage: /purpurinsight <stats-channel|admin-channel> <id> | restart")
+            sender.sendMessage("\u00a7cUsage: /purpurinsight <stats-channel|admin-channel> <id> | restart | link <discordId> | confirm <discordId>")
             return true
         }
 
@@ -53,7 +58,39 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
                 plugin.restartBot()
                 sender.sendMessage("\u00a7aPurpurInsight restarted.")
             }
-            else -> sender.sendMessage("\u00a7cUsage: /purpurinsight <stats-channel|admin-channel> <id> | restart")
+            "link" -> {
+                if (sender !is Player) {
+                    sender.sendMessage("\u00a7cOnly players may link accounts.")
+                    return true
+                }
+                if (args.size != 2) {
+                    sender.sendMessage("\u00a7cUsage: /purpurinsight link <discordId>")
+                    return true
+                }
+                val id = args[1].replace("[^0-9]".toRegex(), "").toLongOrNull()
+                if (id == null) {
+                    sender.sendMessage("\u00a7cInvalid user ID.")
+                    return true
+                }
+                LinkService.createRequest(sender.uniqueId, id)
+                plugin.jda.retrieveUserById(id).queue({ user: User ->
+                    user.openPrivateChannel().queue { ch: MessageChannel ->
+                        ch.sendMessage("Player ${sender.name} wants to link with you.")
+                            .setActionRow(Button.success("link:${sender.uniqueId}", "Yes"))
+                            .queue()
+                    }
+                }, {})
+                sender.sendMessage("\u00a7aRequest sent to Discord user.")
+            }
+            "confirm" -> {
+                if (sender !is Player) return true
+                val id = args.getOrNull(1)?.toLongOrNull() ?: return true
+                if (!LinkService.requestExists(sender.uniqueId, id)) return true
+                LinkService.takeRequest(sender.uniqueId)
+                LinkService.link(sender.uniqueId, id)
+                sender.sendMessage("\u00a7aAccounts linked.")
+            }
+            else -> sender.sendMessage("\u00a7cUsage: /purpurinsight <stats-channel|admin-channel> <id> | restart | link <discordId> | confirm <discordId>")
         }
         return true
     }
@@ -61,7 +98,7 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
     override fun onTabComplete(sender: CommandSender, command: Command, alias: String, args: Array<out String>): MutableList<String>? {
         if (!sender.hasPermission("purpurstats:discordsettings")) return mutableListOf()
         return when (args.size) {
-            1 -> listOf("stats-channel", "admin-channel", "restart").filter { it.startsWith(args[0]) }.toMutableList()
+            1 -> listOf("stats-channel", "admin-channel", "restart", "link", "confirm").filter { it.startsWith(args[0]) }.toMutableList()
             else -> mutableListOf()
         }
     }

--- a/src/main/kotlin/cancelcloud/command/DiscordChannelCommand.kt
+++ b/src/main/kotlin/cancelcloud/command/DiscordChannelCommand.kt
@@ -2,6 +2,7 @@ package cancelcloud.command
 
 import cancelcloud.PurpurInsightPlugin
 import cancelcloud.service.LinkService
+import cancelcloud.service.BotService
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.interactions.components.buttons.Button
@@ -36,7 +37,7 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
                 }
                 plugin.config.set("bot.stats-channel-id", channelId)
                 plugin.saveConfig()
-                plugin.restartBot()
+                BotService.restart()
                 sender.sendMessage("\u00a7aStats channel updated and bot restarted.")
             }
             "admin-channel" -> {
@@ -51,11 +52,11 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
                 }
                 plugin.config.set("bot.admin-channel-id", channelId)
                 plugin.saveConfig()
-                plugin.restartBot()
+                BotService.restart()
                 sender.sendMessage("\u00a7aAdmin channel updated and bot restarted.")
             }
             "restart" -> {
-                plugin.restartBot()
+                BotService.restart()
                 sender.sendMessage("\u00a7aPurpurInsight restarted.")
             }
             "link" -> {
@@ -73,7 +74,7 @@ class DiscordChannelCommand : CommandExecutor, TabCompleter {
                     return true
                 }
                 LinkService.createRequest(sender.uniqueId, id)
-                plugin.jda.retrieveUserById(id).queue({ user: User ->
+                BotService.jda.retrieveUserById(id).queue({ user: User ->
                     user.openPrivateChannel().queue { ch: MessageChannel ->
                         ch.sendMessage("Player ${sender.name} wants to link with you.")
                             .setActionRow(Button.success("link:${sender.uniqueId}", "Yes"))

--- a/src/main/kotlin/cancelcloud/command/LinkDiscordCommand.kt
+++ b/src/main/kotlin/cancelcloud/command/LinkDiscordCommand.kt
@@ -1,0 +1,25 @@
+package cancelcloud.command
+
+import cancelcloud.service.LinkService
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+object LinkDiscordCommand {
+    operator fun invoke(event: SlashCommandInteractionEvent) {
+        val playerName = event.getOption("player")?.asString ?: return
+        val player: Player? = Bukkit.getPlayerExact(playerName)
+        if (player == null) {
+            event.reply("Player not online.").setEphemeral(true).queue()
+            return
+        }
+        val discordId = event.user.idLong
+        LinkService.createRequest(player.uniqueId, discordId)
+
+        val yes = Component.text("[YES]").clickEvent(ClickEvent.runCommand("/purpurinsight confirm $discordId"))
+        player.sendMessage(Component.text("Discord user ${event.user.asTag} wants to link with you. ").append(yes))
+        event.reply("Request sent to ${player.name}.").setEphemeral(true).queue()
+    }
+}

--- a/src/main/kotlin/cancelcloud/service/BotService.kt
+++ b/src/main/kotlin/cancelcloud/service/BotService.kt
@@ -1,0 +1,185 @@
+package cancelcloud.service
+
+import cancelcloud.PurpurInsightPlugin
+import cancelcloud.command.*
+import cancelcloud.config.BotConfig
+import cancelcloud.service.LinkService
+import cancelcloud.util.EmbedBuilderUtil
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.events.session.ReadyEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.requests.GatewayIntent
+import dev.minn.jda.ktx.events.listener
+import dev.minn.jda.ktx.events.onCommand
+import dev.minn.jda.ktx.jdabuilder.intents
+import dev.minn.jda.ktx.jdabuilder.light
+import org.bukkit.scheduler.BukkitTask
+import java.util.UUID
+
+object BotService {
+    lateinit var jda: JDA
+        private set
+
+    private lateinit var plugin: PurpurInsightPlugin
+    private lateinit var botConfig: BotConfig
+    private var autoUpdateMinutes: Long = 30
+    val intervalMinutes: Long
+        get() = autoUpdateMinutes
+    private var updateTask: BukkitTask? = null
+    private var monitorTask: BukkitTask? = null
+    private var playerAlert = false
+    private var memoryAlert = false
+    private var cpuAlert = false
+    private var tpsAlert = false
+    private var diskAlert = false
+
+    fun init(plugin: PurpurInsightPlugin, config: BotConfig) {
+        this.plugin = plugin
+        botConfig = config
+        autoUpdateMinutes = plugin.config.getLong("auto-update-minutes", 30)
+        startBot()
+        startAutoUpdates()
+        startMonitoring()
+    }
+
+    fun restart() {
+        shutdown()
+        botConfig = BotConfig.load(plugin.config)
+        startBot()
+        startAutoUpdates()
+        startMonitoring()
+    }
+
+    fun shutdown() {
+        updateTask?.cancel()
+        monitorTask?.cancel()
+        if (this::jda.isInitialized) {
+            jda.shutdownNow()
+        }
+    }
+
+    fun updateInterval(minutes: Long) {
+        autoUpdateMinutes = minutes
+        plugin.config.set("auto-update-minutes", minutes)
+        plugin.saveConfig()
+        startAutoUpdates()
+    }
+
+    private fun startAutoUpdates() {
+        updateTask?.cancel()
+        if (autoUpdateMinutes <= 0) return
+        val ticks = autoUpdateMinutes * 60L * 20L
+        updateTask = plugin.server.scheduler.runTaskTimer(plugin, Runnable {
+            val stats = StatsService.collectAll()
+            val embed = EmbedBuilderUtil.buildEmbed(stats).build()
+            val channel = jda.getTextChannelById(botConfig.statsChannelId)
+            channel?.sendMessageEmbeds(embed)?.queue()
+        }, ticks, ticks)
+    }
+
+    private fun startMonitoring() {
+        monitorTask?.cancel()
+        val interval = 60L * 20L
+        monitorTask = plugin.server.scheduler.runTaskTimer(plugin, Runnable {
+            val stats = StatsService.collectAll()
+            val channel = jda.getTextChannelById(botConfig.adminChannelId)
+            channel ?: return@Runnable
+
+            val playerLoad = stats.onlinePlayers.toDouble() / stats.maxPlayers
+            if (playerLoad >= 0.8 && !playerAlert) {
+                channel.sendMessage("Player count high: ${stats.onlinePlayers}/${stats.maxPlayers}").queue()
+                playerAlert = true
+            } else if (playerLoad < 0.7) {
+                playerAlert = false
+            }
+
+            val memLoad = stats.ramUsed.toDouble() / stats.ramMax
+            if (memLoad >= 0.9 && !memoryAlert) {
+                channel.sendMessage("Memory usage critical: ${(memLoad*100).toInt()}%").queue()
+                memoryAlert = true
+            } else if (memLoad < 0.8) {
+                memoryAlert = false
+            }
+
+            if (stats.cpuLoad >= 90 && !cpuAlert) {
+                channel.sendMessage("CPU load critical: ${"%.1f".format(stats.cpuLoad)}%").queue()
+                cpuAlert = true
+            } else if (stats.cpuLoad < 80) {
+                cpuAlert = false
+            }
+
+            if (stats.tps1 < 15 && !tpsAlert) {
+                channel.sendMessage("TPS low: ${"%.2f".format(stats.tps1)}").queue()
+                tpsAlert = true
+            } else if (stats.tps1 >= 16) {
+                tpsAlert = false
+            }
+
+            val diskUsage = 1.0 - stats.diskFree.toDouble() / stats.diskTotal
+            if (diskUsage >= 0.9 && !diskAlert) {
+                channel.sendMessage("Disk almost full: ${(diskUsage*100).toInt()}% used").queue()
+                diskAlert = true
+            } else if (diskUsage < 0.85) {
+                diskAlert = false
+            }
+        }, interval, interval)
+    }
+
+    private fun startBot() {
+        jda = light(botConfig.token, enableCoroutines = true) {
+            intents += listOf(
+                GatewayIntent.GUILD_MESSAGES,
+                GatewayIntent.MESSAGE_CONTENT
+            )
+        }
+
+        jda.listener<ReadyEvent> {
+            val guild = it.jda.getGuildById(botConfig.guildId)
+            guild?.upsertCommand(botConfig.commandName, "Zeigt Server-Statistiken")?.queue()
+            guild?.upsertCommand("ping", "Zeigt Bot-Latenz")?.queue()
+            guild?.upsertCommand("auto-updates", "Setzt Intervall für automatische Updates")
+                ?.addOption(OptionType.INTEGER, "minutes", "Intervall in Minuten (0 zum Deaktivieren)", false)
+                ?.queue()
+            guild?.upsertCommand("link", "Verknüpft Discord mit Minecraft")
+                ?.addOption(OptionType.STRING, "player", "Minecraft Spieler", true)
+                ?.queue()
+        }
+
+        jda.onCommand(botConfig.commandName) { event: GenericCommandInteractionEvent ->
+            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
+            StatsCommand(slashEvent)
+        }
+
+        jda.onCommand("ping") { event: GenericCommandInteractionEvent ->
+            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
+            PingCommand(slashEvent)
+        }
+
+        jda.onCommand("auto-updates") { event: GenericCommandInteractionEvent ->
+            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
+            AutoUpdatesCommand(slashEvent)
+        }
+
+        jda.onCommand("link") { event: GenericCommandInteractionEvent ->
+            val slashEvent = event as? SlashCommandInteractionEvent ?: return@onCommand
+            LinkDiscordCommand(slashEvent)
+        }
+
+        jda.listener<ButtonInteractionEvent> { e ->
+            if (e.componentId.startsWith("link:")) {
+                val uuid = UUID.fromString(e.componentId.substringAfter("link:"))
+                val req = LinkService.getRequestByDiscord(e.user.idLong)
+                if (req == uuid) {
+                    LinkService.takeRequest(uuid)
+                    LinkService.link(uuid, e.user.idLong)
+                    e.reply("Accounts linked!").setEphemeral(true).queue()
+                } else {
+                    e.reply("No request found.").setEphemeral(true).queue()
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/cancelcloud/service/LinkService.kt
+++ b/src/main/kotlin/cancelcloud/service/LinkService.kt
@@ -1,0 +1,45 @@
+package cancelcloud.service
+
+import cancelcloud.PurpurInsightPlugin
+import org.bukkit.configuration.file.FileConfiguration
+import org.bukkit.configuration.file.YamlConfiguration
+import java.io.File
+import java.util.UUID
+
+object LinkService {
+    private lateinit var file: File
+    private lateinit var cfg: FileConfiguration
+    private val pending = mutableMapOf<UUID, Long>()
+
+    fun load(plugin: PurpurInsightPlugin) {
+        file = File(plugin.dataFolder, "links.yml")
+        if (!file.exists()) {
+            file.createNewFile()
+        }
+        cfg = YamlConfiguration.loadConfiguration(file)
+    }
+
+    fun getDiscordId(uuid: UUID): Long? {
+        if (!::cfg.isInitialized) return null
+        return cfg.getLong("links.$uuid", 0).takeIf { it != 0L }
+    }
+
+    fun link(uuid: UUID, discordId: Long) {
+        cfg.set("links.$uuid", discordId)
+        save()
+    }
+
+    private fun save() {
+        cfg.save(file)
+    }
+
+    fun createRequest(uuid: UUID, discordId: Long) {
+        pending[uuid] = discordId
+    }
+
+    fun takeRequest(uuid: UUID): Long? = pending.remove(uuid)
+
+    fun requestExists(uuid: UUID, discordId: Long): Boolean = pending[uuid] == discordId
+
+    fun getRequestByDiscord(discordId: Long): UUID? = pending.entries.firstOrNull { it.value == discordId }?.key
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,3 +8,4 @@ bot:
 auto-update-minutes: 30
 
 playtime: {}
+links: {}

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -10,6 +10,6 @@ description: "Sammelt Server-Statistiken und sendet sie per Discord-Slash-Comman
 commands:
   purpurinsight:
     description: "Verwaltet PurpurInsight-Einstellungen"
-    usage: "/purpurinsight <stats-channel|admin-channel> <id> | restart"
+    usage: "/purpurinsight <stats-channel|admin-channel> <id> | restart | link <discordId> | confirm <discordId>"
     permission: purpurstats:discordsettings
     aliases: [purpurinsights]


### PR DESCRIPTION
## Summary
- add account linking logic
- request linking from Minecraft or Discord
- confirm links via commands or buttons
- store linked account ids in `links.yml`

## Testing
- `gradle test` *(fails: Plugin org.gradle.toolchains.foojay-resolver-convention not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9ecb37c832caa8a631072fbd69c