### PR TITLE
Add link flow via Discord channel

### DIFF
--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -10,6 +10,6 @@ description: "Sammelt Server-Statistiken und sendet sie per Discord-Slash-Comman
 commands:
   purpurinsight:
     description: "Verwaltet PurpurInsight-Einstellungen"
-    usage: "/purpurinsight <stats-channel|admin-channel> <id> | restart | link <discordId> | confirm <discordId>"
+    usage: "/purpurinsight <stats-channel|admin-channel> <id> | restart | link <discordName> | confirm <discordId>"
     permission: purpurstats:discordsettings
     aliases: [purpurinsights]


### PR DESCRIPTION
## Summary
- rework linking to use Discord usernames
- send link requests to the configured stats channel with interactive buttons
- update button handling to accept/decline requests and notify both users
- adjust command usage strings

## Testing
- `gradle build` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b8faca3c832ca2386796c1a326d9